### PR TITLE
Move `system.local` and `system.peers` handling into an interface

### DIFF
--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/datastore/InternalDataStore.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/datastore/InternalDataStore.java
@@ -64,7 +64,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.stargate.db.Result;
-import io.stargate.db.cassandra.impl.StargateSystemKeyspace;
 import io.stargate.db.cassandra.impl.Conversion;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.ExecutionInfo;
@@ -307,19 +306,14 @@ public class InternalDataStore implements DataStore
             {
                 try
                 {
-                    long queryStartNanoTime = System.nanoTime();
-                    CQLStatement statement = QueryProcessor.parseStatement(unpreparedCql, queryState.getClientState());
-                    if (!StargateSystemKeyspace.maybeCompleteSystemLocalOrPeersInternal(statement, queryState, queryOptions, queryStartNanoTime, future)) {
-                        ResultMessage resultMessage = QueryProcessor.instance.processStatement(statement, queryState, queryOptions, System.nanoTime());
-                        if (resultMessage instanceof ResultMessage.Rows) {
-                            ResultMessage.Rows rows = (ResultMessage.Rows)resultMessage;
-                            this.pagingState = rows.result.metadata.getPagingState();
-
-                            return;
-                        }
-
-                        future.complete(resultMessage);
+                    CQLStatement statement = QueryProcessor.instance.parse(unpreparedCql, queryState, queryOptions);
+                    ResultMessage resultMessage = QueryProcessor.instance.process(statement, queryState, queryOptions, null, System.nanoTime());
+                    if (resultMessage instanceof ResultMessage.Rows) {
+                        ResultMessage.Rows rows = (ResultMessage.Rows)resultMessage;
+                        this.pagingState = rows.result.metadata.getPagingState();
                     }
+
+                    future.complete(resultMessage);
                 }
                 catch (Throwable t)
                 {
@@ -338,17 +332,13 @@ public class InternalDataStore implements DataStore
             {
                 try
                 {
-                    long queryStartNanoTime = System.nanoTime();
-                    if (!StargateSystemKeyspace.maybeCompleteSystemLocalOrPeersInternal(prepared.statement, queryState, queryOptions, queryStartNanoTime, future))
-                    {
-                        ResultMessage resultMessage = QueryProcessor.instance.processPrepared(prepared.statement, queryState, queryOptions, null, queryStartNanoTime);
-                        if (resultMessage instanceof ResultMessage.Rows) {
-                            ResultMessage.Rows rows = (ResultMessage.Rows)resultMessage;
-                            this.pagingState = rows.result.metadata.getPagingState();
-                        }
-
-                        future.complete(resultMessage);
+                    ResultMessage resultMessage = QueryProcessor.instance.processPrepared(prepared.statement, queryState, queryOptions, null, System.nanoTime());
+                    if (resultMessage instanceof ResultMessage.Rows) {
+                        ResultMessage.Rows rows = (ResultMessage.Rows)resultMessage;
+                        this.pagingState = rows.result.metadata.getPagingState();
                     }
+
+                    future.complete(resultMessage);
                 }
                 catch (Throwable t)
                 {

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -225,10 +225,8 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
 
                 CQLStatement statement = QueryProcessor.parseStatement(cql, Conversion.toInternal(state.getClientState()));
 
-                Result result;
-                if  (interceptor.shouldInterceptQuery(statement, state, options, customPayload, queryStartNanoTime))
-                    result = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
-                else
+                Result result = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
+                if  (result == null)
                 {
                     result = Conversion.toResult(
                             QueryProcessor.instance
@@ -281,10 +279,8 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
                 if (shouldTrace)
                     beginTraceExecute(prepared, state, options, version);
 
-                Result result;
-                if  (interceptor.shouldInterceptQuery(statement, state, options, customPayload, queryStartNanoTime))
-                    result = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
-                else
+                Result result = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
+                if  (result == null)
                 {
                     result = Conversion.toResult(
                             QueryProcessor.instance

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.cassandra.audit.AuditLogManager;
@@ -25,6 +26,7 @@ import org.apache.cassandra.cql3.QueryProcessor;
 import org.apache.cassandra.cql3.VariableSpecifications;
 import org.apache.cassandra.cql3.statements.BatchStatement;
 import org.apache.cassandra.cql3.statements.ModificationStatement;
+import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.service.CassandraDaemon;
@@ -45,6 +47,7 @@ import org.slf4j.LoggerFactory;
 
 import com.datastax.oss.driver.shaded.guava.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Uninterruptibles;
 import io.stargate.db.Authenticator;
 import io.stargate.db.BatchType;
 import io.stargate.db.ClientState;
@@ -54,6 +57,8 @@ import io.stargate.db.QueryOptions;
 import io.stargate.db.QueryState;
 import io.stargate.db.Result;
 import io.stargate.db.cassandra.datastore.InternalDataStore;
+import io.stargate.db.cassandra.impl.interceptors.DefaultQueryInterceptor;
+import io.stargate.db.cassandra.impl.interceptors.QueryInterceptor;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.common.util.SchemaTool;
 
@@ -67,6 +72,7 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
     private CassandraDaemon daemon;
     private Authenticator authenticator;
     private QueryHandler handler;
+    private QueryInterceptor interceptor;
 
     @Override
     public String name()
@@ -80,7 +86,7 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
         logger.info("Initializing CassandraPersistence");
         System.setProperty("cassandra.join_ring", "false");
         daemon = new CassandraDaemon(true);
-        
+
         DatabaseDescriptor.daemonInitialization(() -> config);
         try
         {
@@ -91,16 +97,19 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
             throw new RuntimeException("Unable to start Cassandra persistence layer", e);
         }
 
-        Schema.instance.load(StargateSystemKeyspace.metadata());
+        // Use special gossip state "X10" to differentiate stargate nodes
+        Gossiper.instance.addLocalApplicationState(ApplicationState.X10, StorageService.instance.valueFactory.releaseVersion("stargate"));
 
         daemon.start();
+
+        waitForSchema(StorageService.RING_DELAY);
 
         root = new InternalDataStore();
         authenticator = new AuthenticatorWrapper(DatabaseDescriptor.getAuthenticator());
         handler = org.apache.cassandra.service.ClientState.getCQLQueryHandler();
+        interceptor = new DefaultQueryInterceptor();
 
-        Gossiper.instance.register(new StargateSystemKeyspace.PeersUpdater());
-        StargateSystemKeyspace.persistLocalMetadata();
+        interceptor.initialize();
     }
 
     @Override
@@ -118,8 +127,8 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
     public void registerEventListener(EventListener listener)
     {
         EventListenerWrapper wrapper = new EventListenerWrapper(listener);
-        StorageService.instance.register(wrapper);
         Schema.instance.registerListener(wrapper);
+        interceptor.register(wrapper);
     }
 
     @Override
@@ -215,12 +224,18 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
                     beginTraceQuery(cql, state, options);
 
                 CQLStatement statement = QueryProcessor.parseStatement(cql, Conversion.toInternal(state.getClientState()));
-                if  (!StargateSystemKeyspace.maybeCompleteSystemLocalOrPeers(statement,  internalState, internalOptions, queryStartNanoTime, future))
+
+                Result result;
+                if  (interceptor.shouldInterceptQuery(statement, state, options, customPayload, queryStartNanoTime))
+                    result = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
+                else
                 {
-                    future.complete(Conversion.toResult(
-                            QueryProcessor.instance.processStatement(statement, internalState, internalOptions, queryStartNanoTime), version)
-                            .setTracingId(tracingId));
+                    result = Conversion.toResult(
+                            QueryProcessor.instance
+                                    .processStatement(statement, internalState, internalOptions, queryStartNanoTime), internalOptions.getProtocolVersion());
                 }
+
+                future.complete(result.setTracingId(tracingId));
             }
             catch (Throwable t)
             {
@@ -266,12 +281,17 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
                 if (shouldTrace)
                     beginTraceExecute(prepared, state, options, version);
 
-                if  (!StargateSystemKeyspace.maybeCompleteSystemLocalOrPeers(statement,  internalState, internalOptions, queryStartNanoTime, future))
+                Result result;
+                if  (interceptor.shouldInterceptQuery(statement, state, options, customPayload, queryStartNanoTime))
+                    result = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
+                else
                 {
-                    future.complete(Conversion.toResult(
-                            handler.processPrepared(statement, internalState, internalOptions, customPayload, queryStartNanoTime), version)
-                            .setTracingId(tracingId));
+                    result = Conversion.toResult(
+                            QueryProcessor.instance
+                                    .processPrepared(statement, internalState, internalOptions, queryStartNanoTime), internalOptions.getProtocolVersion());
                 }
+
+                future.complete(result.setTracingId(tracingId));
             }
             catch (Throwable t)
             {
@@ -521,5 +541,24 @@ public class CassandraPersistence implements Persistence<Config, org.apache.cass
 
         // TODO we don't have [typed] access to CQL bind variables here.  CASSANDRA-4560 is open to add support.
         Tracing.instance.begin("Execute batch of CQL3 queries", state.getClientAddress(), builder.build());
+    }
+
+    /**
+     * When "cassandra.join_ring" is "false" {@link StorageService#initServer()}  will not wait for schema to propagate to the coordinator only node. This
+     * method fixes that limitation by waiting for at least one backend ring member to become available and for their schemas to agree before allowing
+     * initialization to continue.
+     */
+    private void waitForSchema(int delay)
+    {
+        for (int i = 0; i < delay; i += 1000)
+        {
+            if (Gossiper.instance.getLiveTokenOwners().size() > 0 && isInSchemaAgreement())
+            {
+                logger.debug("current schema version: {}", Schema.instance.getVersion());
+                break;
+            }
+
+            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+        }
     }
 }

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/Conversion.java
@@ -248,7 +248,7 @@ public class Conversion
     {
         ResultMessage.SchemaChange schemaChange = (ResultMessage.SchemaChange)resultMessage;
         Event.SchemaChange change = schemaChange.change;
-        return new Result.SchemaChangeMetadata(change.target.toString(), change.target.toString(), change.keyspace, change.name, change.argTypes);
+        return new Result.SchemaChangeMetadata(change.change.toString(), change.target.toString(), change.keyspace, change.name, change.argTypes);
     }
 
     public static Result toResult(ResultMessage resultMessage, org.apache.cassandra.transport.ProtocolVersion version)

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
@@ -1,0 +1,167 @@
+package io.stargate.db.cassandra.impl.interceptors;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryHandler;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.ResultSet;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
+import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.locator.InetAddressAndPort;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.TableMetadata;
+import org.apache.cassandra.service.IEndpointLifecycleSubscriber;
+import org.apache.cassandra.transport.messages.ResultMessage;
+
+import com.google.common.collect.Sets;
+import io.stargate.db.QueryOptions;
+import io.stargate.db.QueryState;
+import io.stargate.db.Result;
+import io.stargate.db.cassandra.impl.Conversion;
+import io.stargate.db.cassandra.impl.StargateSystemKeyspace;
+
+import static io.stargate.db.cassandra.impl.StargateSystemKeyspace.isStargateNode;
+import static io.stargate.db.cassandra.impl.StargateSystemKeyspace.isSystemLocalOrPeers;
+import static io.stargate.db.cassandra.impl.StargateSystemKeyspace.isSystemPeers;
+import static io.stargate.db.cassandra.impl.StargateSystemKeyspace.isSystemPeersV2;
+
+/**
+ * A default interceptor implementation that returns only stargate nodes for `system.peers` queries, but also
+ * returns only the same, single token for all stargate nodes (they all own the whole ring) for both `system.local`
+ * and `system.peers` tables.
+ */
+public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointStateChangeSubscriber
+{
+    private final List<IEndpointLifecycleSubscriber> subscribers = new CopyOnWriteArrayList<>();
+    private final Set<InetAddressAndPort> liveStargateNodes = Sets.newConcurrentHashSet();
+
+    @Override
+    public void initialize()
+    {
+        Schema.instance.load(StargateSystemKeyspace.metadata());
+        Gossiper.instance.register(new StargateSystemKeyspace.PeersUpdater());
+        Gossiper.instance.register(this);
+        StargateSystemKeyspace.persistLocalMetadata();
+    }
+
+    @Override
+    public boolean shouldInterceptQuery(CQLStatement statement,
+                                        QueryState state, QueryOptions options,
+                                        Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
+    {
+        return isSystemLocalOrPeers(statement);
+    }
+
+    @Override
+    public Result interceptQuery(QueryHandler handler, CQLStatement statement,
+                               QueryState state, QueryOptions options,
+                               Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
+    {
+        org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
+        org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);
+        return Conversion.toResult(interceptSystemLocalOrPeers(statement, internalState, internalOptions, queryStartNanoTime), internalOptions.getProtocolVersion());
+    }
+
+    @Override
+    public void register(IEndpointLifecycleSubscriber subscriber)
+    {
+        subscribers.add(subscriber);
+    }
+
+    @Override
+    public void onJoin(InetAddressAndPort endpoint, EndpointState epState)
+    {
+        addStargateNode(endpoint, epState);
+    }
+
+    @Override
+    public void beforeChange(InetAddressAndPort endpoint, EndpointState currentState, ApplicationState newStateKey, VersionedValue newValue)
+    {
+
+    }
+
+    @Override
+    public void onChange(InetAddressAndPort endpoint, ApplicationState state, VersionedValue value)
+    {
+        EndpointState epState = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
+        if (epState == null || Gossiper.instance.isDeadState(epState))
+        {
+            return;
+        }
+
+        addStargateNode(endpoint, epState);
+    }
+
+    @Override
+    public void onAlive(InetAddressAndPort endpoint, EndpointState state)
+    {
+
+    }
+
+    @Override
+    public void onDead(InetAddressAndPort endpoint, EndpointState state)
+    {
+
+    }
+
+    @Override
+    public void onRemove(InetAddressAndPort endpoint)
+    {
+        if (!liveStargateNodes.remove(endpoint))
+        {
+            return;
+        }
+
+        for (IEndpointLifecycleSubscriber subscriber : subscribers)
+            subscriber.onLeaveCluster(endpoint);
+    }
+
+    @Override
+    public void onRestart(InetAddressAndPort endpoint, EndpointState state)
+    {
+
+    }
+
+    private void addStargateNode(InetAddressAndPort endpoint, EndpointState epState)
+    {
+        if (!isStargateNode(epState) || !liveStargateNodes.add(endpoint))
+        {
+            return;
+        }
+
+        for (IEndpointLifecycleSubscriber subscriber : subscribers)
+            subscriber.onJoinCluster(endpoint);
+    }
+
+    private static ResultMessage.Rows interceptSystemLocalOrPeers(CQLStatement statement, org.apache.cassandra.service.QueryState state, org.apache.cassandra.cql3.QueryOptions options, long queryStartNanoTime)
+    {
+        SelectStatement selectStatement = (SelectStatement) statement;
+        TableMetadata tableMetadata = StargateSystemKeyspace.Local;
+        if (isSystemPeers(selectStatement))
+            tableMetadata = StargateSystemKeyspace.Peers;
+        else if (isSystemPeersV2(selectStatement))
+            tableMetadata = StargateSystemKeyspace.PeersV2;
+        SelectStatement interceptStatement =
+                new SelectStatement(tableMetadata,
+                        selectStatement.bindVariables,
+                        selectStatement.parameters,
+                        selectStatement.getSelection(),
+                        selectStatement.getRestrictions(),
+                        false,
+                        null,
+                        null,
+                        null,
+                        null);
+        ResultMessage.Rows rows = interceptStatement.execute(state, options, queryStartNanoTime);
+        return new ResultMessage.Rows(new ResultSet(selectStatement.getResultMetadata(), rows.result.rows));
+    }
+}

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/DefaultQueryInterceptor.java
@@ -54,18 +54,15 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
     }
 
     @Override
-    public boolean shouldInterceptQuery(CQLStatement statement,
-                                        QueryState state, QueryOptions options,
-                                        Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
-    {
-        return isSystemLocalOrPeers(statement);
-    }
-
-    @Override
     public Result interceptQuery(QueryHandler handler, CQLStatement statement,
                                QueryState state, QueryOptions options,
                                Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
     {
+        if (!isSystemLocalOrPeers(statement))
+        {
+            return null;
+        }
+
         org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
         org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);
         return Conversion.toResult(interceptSystemLocalOrPeers(statement, internalState, internalOptions, queryStartNanoTime), internalOptions.getProtocolVersion());

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
@@ -1,0 +1,32 @@
+package io.stargate.db.cassandra.impl.interceptors;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryHandler;
+import org.apache.cassandra.service.IEndpointLifecycleSubscriber;
+
+import io.stargate.db.QueryOptions;
+import io.stargate.db.QueryState;
+import io.stargate.db.Result;
+
+/**
+ * An interface for intercepting queries and node lifecycle events. It's used to intercept `system.local`
+ * and `system.peers` queries and topology events for stargate nodes.
+ */
+public interface QueryInterceptor
+{
+    void initialize();
+
+    boolean shouldInterceptQuery(CQLStatement statement,
+                                 QueryState state, QueryOptions options,
+                                 Map<String, ByteBuffer> customPayload, long queryStartNanoTime);
+
+    Result interceptQuery(QueryHandler handler, CQLStatement statement,
+                          QueryState state, QueryOptions options,
+                          Map<String, ByteBuffer> customPayload, long queryStartNanoTime);
+
+    void register(IEndpointLifecycleSubscriber subscriber);
+}

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/interceptors/QueryInterceptor.java
@@ -20,10 +20,6 @@ public interface QueryInterceptor
 {
     void initialize();
 
-    boolean shouldInterceptQuery(CQLStatement statement,
-                                 QueryState state, QueryOptions options,
-                                 Map<String, ByteBuffer> customPayload, long queryStartNanoTime);
-
     Result interceptQuery(QueryHandler handler, CQLStatement statement,
                           QueryState state, QueryOptions options,
                           Map<String, ByteBuffer> customPayload, long queryStartNanoTime);

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/datastore/DataStoreUtil.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/datastore/DataStoreUtil.java
@@ -1,4 +1,4 @@
-package io.stargate.db.dse.datastax;
+package io.stargate.db.dse.datastore;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/datastore/InternalDataStore.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/datastore/InternalDataStore.java
@@ -3,7 +3,7 @@
  *
  * Please see the included license file for details.
  */
-package io.stargate.db.dse.datastax;
+package io.stargate.db.dse.datastore;
 
 import javax.inject.Inject;
 import java.nio.ByteBuffer;
@@ -283,8 +283,7 @@ public class InternalDataStore implements DataStore
         private Single<ResultMessage> queryUnprepared()
         {
             return QueryProcessor.instance
-                    .process(unpreparedCql, queryState, queryOptions, null, ApolloTime.approximateNanoTime())
-                    // Solr queries need to be executed on a TPC thread since DSP-15891
+                    .process(unpreparedCql, queryState, queryOptions, ApolloTime.approximateNanoTime())
                     .subscribeOn(TPC.bestTPCScheduler());
         }
 

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/datastore/InternalResultSet.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/datastore/InternalResultSet.java
@@ -3,7 +3,7 @@
  *
  * Please see the included license file for details.
  */
-package io.stargate.db.dse.datastax;
+package io.stargate.db.dse.datastore;
 
 import javax.validation.constraints.NotNull;
 import java.nio.ByteBuffer;

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/Conversion.java
@@ -55,7 +55,7 @@ import io.stargate.db.Result;
 import io.stargate.db.datastore.DataStore;
 import io.stargate.db.datastore.schema.Column;
 import io.stargate.db.datastore.schema.ImmutableColumn;
-import io.stargate.db.dse.datastax.DataStoreUtil;
+import io.stargate.db.dse.datastore.DataStoreUtil;
 
 public class Conversion
 {
@@ -275,7 +275,7 @@ public class Conversion
     {
         ResultMessage.SchemaChange schemaChange = (ResultMessage.SchemaChange)resultMessage;
         Event.SchemaChange change = schemaChange.change;
-        return new Result.SchemaChangeMetadata(change.target.toString(), change.target.toString(), change.keyspace, change.name, change.argTypes);
+        return new Result.SchemaChangeMetadata(change.change.toString(), change.target.toString(), change.keyspace, change.name, change.argTypes);
     }
 
     public static Result toResult(ResultMessage resultMessage, org.apache.cassandra.transport.ProtocolVersion version)

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -1,16 +1,15 @@
 package io.stargate.db.dse.impl;
 
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.cassandra.auth.AuthenticatedUser;
@@ -22,18 +21,12 @@ import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.ColumnSpecification;
 import org.apache.cassandra.cql3.QueryHandler;
 import org.apache.cassandra.cql3.QueryProcessor;
-import org.apache.cassandra.cql3.ResultSet;
 import org.apache.cassandra.cql3.statements.BatchStatement;
 import org.apache.cassandra.cql3.statements.ModificationStatement;
-import org.apache.cassandra.cql3.statements.SelectStatement;
-import org.apache.cassandra.db.marshal.InetAddressType;
-import org.apache.cassandra.db.marshal.Int32Type;
-import org.apache.cassandra.db.marshal.SetType;
-import org.apache.cassandra.db.marshal.UTF8Type;
-import org.apache.cassandra.db.marshal.UUIDType;
 import org.apache.cassandra.exceptions.InvalidRequestException;
+import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.Gossiper;
-import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.gms.VersionedValue;
 import org.apache.cassandra.schema.SchemaManager;
 import org.apache.cassandra.service.CassandraDaemon;
 import org.apache.cassandra.service.ClientState;
@@ -44,17 +37,16 @@ import org.apache.cassandra.stargate.exceptions.PreparedQueryNotFoundException;
 import org.apache.cassandra.stargate.locator.InetAddressAndPort;
 import org.apache.cassandra.stargate.utils.MD5Digest;
 import org.apache.cassandra.tracing.Tracing;
-import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.transport.messages.ResultMessage;
 import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.datastax.bdp.db.nodes.virtual.LocalNodeSystemView;
-import com.datastax.bdp.db.nodes.virtual.PeersSystemView;
+import com.datastax.bdp.db.util.ProductVersion;
 import com.datastax.bdp.util.SchemaTool;
 import com.datastax.oss.driver.shaded.guava.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Uninterruptibles;
 import io.reactivex.Single;
 import io.stargate.db.Authenticator;
 import io.stargate.db.BatchType;
@@ -64,7 +56,10 @@ import io.stargate.db.QueryOptions;
 import io.stargate.db.QueryState;
 import io.stargate.db.Result;
 import io.stargate.db.datastore.DataStore;
-import io.stargate.db.dse.datastax.InternalDataStore;
+import io.stargate.db.dse.datastore.InternalDataStore;
+import io.stargate.db.dse.impl.interceptors.DefaultQueryInterceptor;
+import io.stargate.db.dse.impl.interceptors.ProxyProtocolQueryInterceptor;
+import io.stargate.db.dse.impl.interceptors.QueryInterceptor;
 
 public class DsePersistence implements Persistence<Config, org.apache.cassandra.service.ClientState, org.apache.cassandra.service.QueryState>
 {
@@ -76,6 +71,7 @@ public class DsePersistence implements Persistence<Config, org.apache.cassandra.
     private DataStore root;
     private Authenticator authenticator;
     private QueryHandler handler;
+    private QueryInterceptor interceptor;
 
     @Override
     public String name()
@@ -96,6 +92,8 @@ public class DsePersistence implements Persistence<Config, org.apache.cassandra.
         DatabaseDescriptor.daemonInitialization(true, config);
         cassandraDaemon = new CassandraDaemon(true);
 
+        StorageService.instance.valueFactory = new ValueFactory();
+
         // CassandraDaemon.activate() creates a thread that swallows exceptions that occur during startup. Use
         // an UnauthorizedExceptionHandler to check for failure.
         AtomicReference<Throwable> throwableFromMainThread = new AtomicReference<>();
@@ -115,15 +113,21 @@ public class DsePersistence implements Persistence<Config, org.apache.cassandra.
             throw new RuntimeException("Unable to start DSE persistence layer", t);
         }
 
-        StargateSystemKeyspace.initialize();
+        // Use special gossip state "X10" to differentiate stargate nodes
+        Gossiper.instance.addLocalApplicationState(ApplicationState.X10, StorageService.instance.valueFactory.dsefsState("stargate"));
+
+        waitForSchema(StorageService.RING_DELAY);
+
+        if (USE_PROXY_PROTOCOL)
+            interceptor = new ProxyProtocolQueryInterceptor();
+        else
+            interceptor = new DefaultQueryInterceptor();
+
+        interceptor.initialize();
 
         root = new InternalDataStore();
         authenticator = new AuthenticatorWrapper(DatabaseDescriptor.getAuthenticator());
         handler = ClientState.getCQLQueryHandler();
-
-        Gossiper.instance.register(StargateSystemKeyspace.instance.getPeersUpdater());
-
-        StargateSystemKeyspace.instance.persistLocalMetadata();
     }
 
     @Override
@@ -141,8 +145,8 @@ public class DsePersistence implements Persistence<Config, org.apache.cassandra.
     public void registerEventListener(EventListener listener)
     {
         EventListenerWrapper wrapper = new EventListenerWrapper(listener);
-        StorageService.instance.register(wrapper);
         SchemaManager.instance.registerListener(wrapper);
+        interceptor.register(wrapper);
     }
 
     @Override
@@ -217,27 +221,25 @@ public class DsePersistence implements Persistence<Config, org.apache.cassandra.
     {
         try
         {
-            ProtocolVersion version = Conversion.toInternal(options.getProtocolVersion());
             org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
             org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);
 
             return Conversion.toFuture(Single.defer(() ->
             {
-                final UUID tracingId = beginTraceQuery(cql, internalState, internalOptions, customPayload, isTracingRequested);
-
-                Single<Result> resp = Single.defer(() ->
+                try
                 {
+                    final UUID tracingId = beginTraceQuery(cql, internalState, internalOptions, customPayload, isTracingRequested);
+
                     checkIsLoggedIn(internalState);
 
                     CQLStatement statement = QueryProcessor.parseStatement(cql, internalState);
-                    return maybeHandleSystemLocalOrPeers(statement, state, version, tracingId, handler
-                            .processStatement(statement, internalState, internalOptions, customPayload, queryStartNanoTime));
-                });
 
-                return resp
-                        .flatMap(result -> Tracing.instance.stopSessionAsync().toSingleDefault(result))
-                        .onErrorResumeNext((e) -> Single.error(Conversion.handleException(e)))
-                        .subscribeOn(TPC.bestTPCScheduler());
+                    return processStatement(statement, state, options, customPayload, queryStartNanoTime, tracingId);
+                }
+                catch (Exception e)
+                {
+                    return Single.error(Conversion.handleException(e));
+                }
             }));
         }
         catch (Exception e)
@@ -252,32 +254,30 @@ public class DsePersistence implements Persistence<Config, org.apache.cassandra.
     {
         try
         {
-            ProtocolVersion version = Conversion.toInternal(options.getProtocolVersion());
             org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
             org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);
 
             return Conversion.toFuture(Single.defer(() ->
             {
-                QueryHandler.Prepared prepared = handler.getPrepared(Conversion.toInternal(id));
-                if (prepared == null)
+                try
                 {
-                    return Single.error(new PreparedQueryNotFoundException(id));
-                }
+                    QueryHandler.Prepared prepared = handler.getPrepared(Conversion.toInternal(id));
+                    if (prepared == null)
+                    {
+                        return Single.error(new PreparedQueryNotFoundException(id));
+                    }
 
-                final CQLStatement statement = prepared.statement;
-                final UUID tracingId = beginTraceExecute(statement, internalState, internalOptions, customPayload, isTracingRequested);
+                    final CQLStatement statement = prepared.statement;
+                    final UUID tracingId = beginTraceExecute(statement, internalState, internalOptions, customPayload, isTracingRequested);
 
-                Single<Result> resp = Single.defer(() ->
-                {
                     checkIsLoggedIn(internalState);
-                    return maybeHandleSystemLocalOrPeers(statement, state, version, tracingId, handler
-                            .processStatement(statement, internalState, internalOptions, customPayload, queryStartNanoTime));
-                });
 
-                return resp
-                        .flatMap(result -> Tracing.instance.stopSessionAsync().toSingleDefault(result))
-                        .onErrorResumeNext((e) -> Single.error(Conversion.handleException(e)))
-                        .subscribeOn(TPC.bestTPCScheduler());
+                    return processStatement(statement, state, options, customPayload, queryStartNanoTime, tracingId);
+                }
+                catch (Exception e)
+                {
+                    return Single.error(Conversion.handleException(e));
+                }
             }));
         }
         catch (Exception e)
@@ -510,71 +510,61 @@ public class DsePersistence implements Persistence<Config, org.apache.cassandra.
 
     }
 
-    private Single<Result> maybeHandleSystemLocalOrPeers(CQLStatement statement, QueryState state, ProtocolVersion version, UUID tracingId, Single<ResultMessage> single)
+    private Single<Result> processStatement(CQLStatement statement,
+                                            QueryState state, QueryOptions options,
+                                            Map<String, ByteBuffer> customPayload, long queryStartNanoTime,
+                                            UUID tracingId)
     {
-        // If we're using proxy protocol then return return the public IPs as entries from `system.local` and `system.peers`
-        if (USE_PROXY_PROTOCOL && statement instanceof SelectStatement)
+        Single<Result> resp;
+        if (interceptor.shouldInterceptQuery(statement, state, options, customPayload, queryStartNanoTime))
+            resp = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
+        else
         {
-            SelectStatement selectStatement = (SelectStatement) statement;
+            org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
+            org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);
 
-            if (selectStatement.keyspace().equals(SchemaConstants.SYSTEM_VIEWS_KEYSPACE_NAME))
-            {
-                String tableName = selectStatement.table();
-                if (tableName.equals(PeersSystemView.NAME))
-                {
-                    // Returning an empty result for now, but this will return the result of the proxy's DNS A records in the future
-                    return single.flatMap((r) -> Single.just(Conversion.toResult(new ResultMessage.Rows(new org.apache.cassandra.cql3.ResultSet(((SelectStatement) statement).getResultMetadata())), version)));
-                }
-                else if (tableName.equals(LocalNodeSystemView.NAME))
-                {
-                    return single
-                            .map((result) ->
-                            {
-                                if (result.kind == ResultMessage.Kind.ROWS)
-                                {
-                                    ResultMessage.Rows rows = (ResultMessage.Rows) result;
-                                    if (!rows.result.isEmpty())
-                                    {
-                                        ResultSet.ResultMetadata metadata = rows.result.metadata;
-                                        InetAddress publicAddress = state.getClientState().getPublicAddress().getAddress();
-                                        int publicPort = state.getClientState().getPublicAddress().getPort();
-
-                                        int index = 0;
-                                        // Intercept and replace all address/port entries with the proxy protocol's public address and port
-                                        for (ColumnSpecification column : metadata.names)
-                                        {
-                                            switch (column.name.toString())
-                                            {
-                                                case "rpc_address":
-                                                case "peer_address":
-                                                case "broadcast_address":
-                                                case "native_transport_address":
-                                                case "listen_address":
-                                                    rows.result.rows.get(0).set(index, InetAddressType.instance.decompose(publicAddress));
-                                                    break;
-                                                case "native_transport_port":
-                                                case "native_transport_port_ssl":
-                                                    rows.result.rows.get(0).set(index, Int32Type.instance.decompose(publicPort));
-                                                    break;
-                                                case "host_id":
-                                                    // Return a deterministic entry for `host_id` based on the public address.
-                                                    rows.result.rows.get(0).set(index, UUIDType.instance.decompose(UUID.nameUUIDFromBytes(publicAddress.getAddress())));
-                                                    break;
-                                                case "tokens":
-                                                    // All entries handle the entire token ring. This prevents some driver from crashing when `tokens` is null.
-                                                    rows.result.rows.get(0).set(index, SetType.getInstance(UTF8Type.instance, false).decompose(Collections.singleton(DatabaseDescriptor.getPartitioner().getMinimumToken().toString())));
-                                            }
-                                            ++index;
-                                        }
-                                    }
-                                }
-                                return Conversion.toResult(result, version).setTracingId(tracingId);
-                            });
-                }
-            }
+            resp = handler
+                    .processStatement(statement, internalState, internalOptions, customPayload, queryStartNanoTime)
+                    .map(r -> Conversion.toResult(r, internalOptions.getProtocolVersion()));
         }
 
-        return single.map(result -> Conversion.toResult(result, version).setTracingId(tracingId));
+        return resp
+                .map(r -> r.setTracingId(tracingId))
+                .flatMap(result -> Tracing.instance.stopSessionAsync().toSingleDefault(result))
+                .onErrorResumeNext((e) -> Single.error(Conversion.handleException(e)))
+                .subscribeOn(TPC.bestTPCScheduler());
     }
 
+    /**
+     * When "cassandra.join_ring" is "false" {@link StorageService#initServer()}  will not wait for schema to propagate to the coordinator only node. This
+     * method fixes that limitation by waiting for at least one backend ring member to become available and for their schemas to agree before allowing
+     * initialization to continue.
+     */
+    private void waitForSchema(int delay)
+    {
+        for (int i = 0; i < delay; i += 1000)
+        {
+            if (Gossiper.instance.getLiveTokenOwners().size() > 0 && isInSchemaAgreement())
+            {
+                logger.debug("current schema version: {}", SchemaManager.instance.getVersion());
+                break;
+            }
+
+            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+        }
+    }
+
+    private static class ValueFactory extends VersionedValue.VersionedValueFactory {
+        public ValueFactory()
+        {
+            super(StorageService.instance.getTokenMetadata().partitioner);
+        }
+
+        @Override
+        public VersionedValue releaseVersion()
+        {
+            // This is hack because there is no version that takes a string and VersionedValue's constructor is private.
+            return dsefsState(ProductVersion.getReleaseVersionString() + "-stargate");
+        }
+    }
 }

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -92,8 +92,6 @@ public class DsePersistence implements Persistence<Config, org.apache.cassandra.
         DatabaseDescriptor.daemonInitialization(true, config);
         cassandraDaemon = new CassandraDaemon(true);
 
-        StorageService.instance.valueFactory = new ValueFactory();
-
         // CassandraDaemon.activate() creates a thread that swallows exceptions that occur during startup. Use
         // an UnauthorizedExceptionHandler to check for failure.
         AtomicReference<Throwable> throwableFromMainThread = new AtomicReference<>();
@@ -551,20 +549,6 @@ public class DsePersistence implements Persistence<Config, org.apache.cassandra.
             }
 
             Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-        }
-    }
-
-    private static class ValueFactory extends VersionedValue.VersionedValueFactory {
-        public ValueFactory()
-        {
-            super(StorageService.instance.getTokenMetadata().partitioner);
-        }
-
-        @Override
-        public VersionedValue releaseVersion()
-        {
-            // This is hack because there is no version that takes a string and VersionedValue's constructor is private.
-            return dsefsState(ProductVersion.getReleaseVersionString() + "-stargate");
         }
     }
 }

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -26,7 +26,6 @@ import org.apache.cassandra.cql3.statements.ModificationStatement;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.Gossiper;
-import org.apache.cassandra.gms.VersionedValue;
 import org.apache.cassandra.schema.SchemaManager;
 import org.apache.cassandra.service.CassandraDaemon;
 import org.apache.cassandra.service.ClientState;
@@ -42,7 +41,6 @@ import org.apache.cassandra.utils.JVMStabilityInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.datastax.bdp.db.util.ProductVersion;
 import com.datastax.bdp.util.SchemaTool;
 import com.datastax.oss.driver.shaded.guava.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -513,10 +511,8 @@ public class DsePersistence implements Persistence<Config, org.apache.cassandra.
                                             Map<String, ByteBuffer> customPayload, long queryStartNanoTime,
                                             UUID tracingId)
     {
-        Single<Result> resp;
-        if (interceptor.shouldInterceptQuery(statement, state, options, customPayload, queryStartNanoTime))
-            resp = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
-        else
+        Single<Result> resp = interceptor.interceptQuery(handler, statement, state, options, customPayload, queryStartNanoTime);
+        if (resp == null)
         {
             org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
             org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateLocalView.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateLocalView.java
@@ -10,7 +10,7 @@ public class StargateLocalView extends StargateNodeView
 {
     StargateLocalView()
     {
-        super(NodesSystemViews.virtualFromLegacy(NodesSystemViews.Local, LocalNodeSystemView.NAME));
+        super(StargateSystemKeyspace.virtualFromLegacy(NodesSystemViews.Local, StargateSystemKeyspace.LOCAL_TABLE_NAME));
     }
 
     @Override

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargatePeersView.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargatePeersView.java
@@ -3,13 +3,12 @@ package io.stargate.db.dse.impl;
 import org.apache.cassandra.db.virtual.DataSet;
 
 import com.datastax.bdp.db.nodes.virtual.NodesSystemViews;
-import com.datastax.bdp.db.nodes.virtual.PeersSystemView;
 
 public class StargatePeersView extends StargateNodeView
 {
     StargatePeersView()
     {
-        super(NodesSystemViews.virtualFromLegacy(NodesSystemViews.Peers, PeersSystemView.NAME));
+        super(StargateSystemKeyspace.virtualFromLegacy(NodesSystemViews.Peers, StargateSystemKeyspace.PEERS_TABLE_NAME));
     }
 
     @Override

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateSystemKeyspace.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/StargateSystemKeyspace.java
@@ -2,24 +2,25 @@ package io.stargate.db.dse.impl;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLStatement;
 import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.statements.SelectStatement;
 import org.apache.cassandra.db.virtual.VirtualKeyspace;
-import org.apache.cassandra.db.virtual.VirtualTable;
 import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.EndpointState;
 import org.apache.cassandra.gms.Gossiper;
 import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
 import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.schema.MigrationManager;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.SchemaManager;
-import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.transport.ProtocolVersion;
 import org.apache.cassandra.utils.FBUtilities;
 import org.slf4j.Logger;
@@ -35,6 +36,9 @@ public class StargateSystemKeyspace
 {
     private static final Logger logger = LoggerFactory.getLogger(StargateSystemKeyspace.class);
 
+    public static final String SYSTEM_KEYSPACE_NAME = "stargate_system";
+    public static final String LOCAL_TABLE_NAME = "local";
+    public static final String PEERS_TABLE_NAME = "peers";
     public static final UUID SCHEMA_VERSION = UUID.fromString("17846767-28a1-4acd-a967-f609ff1375f1");
 
     public final static StargateSystemKeyspace instance = new StargateSystemKeyspace();
@@ -73,6 +77,28 @@ public class StargateSystemKeyspace
         local.setHostId(Nodes.local().get().getHostId());
     }
 
+    public static boolean isSystemLocal(SelectStatement statement)
+    {
+        return statement.table().equals(LocalNodeSystemView.NAME);
+    }
+
+    public static boolean isSystemLocalOrPeers(CQLStatement statement)
+    {
+        if (statement instanceof SelectStatement)
+        {
+            SelectStatement selectStatement = (SelectStatement) statement;
+            return selectStatement.keyspace().equals(SchemaConstants.SYSTEM_VIEWS_KEYSPACE_NAME) &&
+                    (isSystemLocal(selectStatement) || selectStatement.table().equals(PeersSystemView.NAME));
+        }
+        return false;
+    }
+
+    public static boolean isStargateNode(EndpointState epState)
+    {
+        VersionedValue value = epState.getApplicationState(ApplicationState.X10);
+        return value != null && value.value.equals("stargate");
+    }
+
     public IEndpointStateChangeSubscriber getPeersUpdater()
     {
         return new PeersUpdater();
@@ -80,23 +106,9 @@ public class StargateSystemKeyspace
 
     public static void initialize()
     {
-        List<VirtualTable> tables = SchemaManager.instance.getVirtualKeyspaceInstance(SchemaConstants.SYSTEM_VIEWS_KEYSPACE_NAME).tables();
-        VirtualKeyspace.Builder builder = VirtualKeyspace.newBuilder(SchemaConstants.SYSTEM_VIEWS_KEYSPACE_NAME);
-        for (VirtualTable table : tables)
-        {
-            if (table.name().equals(PeersSystemView.NAME))
-            {
-                builder.addView(new StargatePeersView());
-            }
-            else if (table.name().equals((LocalNodeSystemView.NAME)))
-            {
-                builder.addView(new StargateLocalView());
-            }
-            else
-            {
-                builder.addView(table);
-            }
-        }
+        VirtualKeyspace.Builder builder = VirtualKeyspace.newBuilder(SYSTEM_KEYSPACE_NAME)
+                .addView(new StargatePeersView())
+                .addView(new StargateLocalView());
         SchemaManager.instance.load(builder.build());
     }
 
@@ -105,9 +117,12 @@ public class StargateSystemKeyspace
         @Override
         public void onJoin(InetAddress endpoint, EndpointState epState)
         {
+            if (!isStargateNode(epState))
+                return;
+
             for (Map.Entry<ApplicationState, VersionedValue> entry : epState.states())
             {
-                onChange(endpoint, entry.getKey(), entry.getValue());
+                applyState(endpoint, entry.getKey(), entry.getValue(), epState);
             }
         }
 
@@ -131,56 +146,16 @@ public class StargateSystemKeyspace
                 return;
             }
 
-            if (FBUtilities.getLocalAddress().equals(endpoint) || StorageService.instance.getTokenMetadata().isMember(endpoint))  // We only want stargate nodes (no members)
+            // We only want stargate nodes
+            if (FBUtilities.getLocalAddress().equals(endpoint) || !isStargateNode(epState))
             {
                 return;
             }
 
-            StargatePeerInfo peer = peers.computeIfAbsent(endpoint, StargatePeerInfo::new);
-
-            switch (state)
-            {
-                case RELEASE_VERSION:
-                    peer.setReleaseVersion(value.value);
-                    break;
-                case DC:
-                    peer.setDataCenter(value.value);
-                    break;
-                case RACK:
-                    peer.setRack(value.value);
-                    break;
-                case NATIVE_TRANSPORT_ADDRESS:
-                    try
-                    {
-                        peer.setNativeAddress(InetAddress.getByName(value.value));
-                    }
-                    catch (UnknownHostException e)
-                    {
-                        throw new RuntimeException(e);
-                    }
-                    break;
-                case NATIVE_TRANSPORT_PORT:
-                    peer.setNativePort(Integer.parseInt(value.value));
-                    break;
-                case NATIVE_TRANSPORT_PORT_SSL:
-                    peer.setNativePortSsl(Integer.parseInt(value.value));
-                    break;
-                case STORAGE_PORT:
-                    peer.setStoragePort(Integer.parseInt(value.value));
-                    break;
-                case STORAGE_PORT_SSL:
-                    peer.setStoragePortSsl(Integer.parseInt(value.value));
-                    break;
-                case JMX_PORT:
-                    peer.setJmxPort(Integer.parseInt(value.value));
-                    break;
-                case HOST_ID:
-                    peer.setHostId(UUID.fromString(value.value));
-                    break;
-                case DSE_GOSSIP_STATE:
-                    updateDseState(value, endpoint, peer);
-                    break;
-            }
+            if (peers.containsKey(endpoint))
+                applyState(endpoint, state, value, epState);
+            else
+                onJoin(endpoint, epState);
         }
 
         private void updateDseState(VersionedValue value, InetAddress endpoint, StargatePeerInfo peer)
@@ -214,5 +189,70 @@ public class StargateSystemKeyspace
         public void onRestart(InetAddress endpoint, EndpointState state)
         {
         }
+
+        private void applyState(InetAddress endpoint, ApplicationState state, VersionedValue value, EndpointState epState)
+        {
+            StargatePeerInfo peer = peers.computeIfAbsent(endpoint, StargatePeerInfo::new);
+
+            switch (state)
+            {
+                case RELEASE_VERSION:
+                    peer.setReleaseVersion(value.value);
+                    break;
+                case DC:
+                    peer.setDataCenter(value.value);
+                    break;
+                case RACK:
+                    peer.setRack(value.value);
+                    break;
+                case NATIVE_TRANSPORT_ADDRESS:
+                    try
+                    {
+                        peer.setNativeAddress(InetAddress.getByName(value.value));
+                    }
+                    catch (UnknownHostException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    break;
+                case NATIVE_TRANSPORT_PORT:
+                    peer.setNativePort(Integer.parseInt(value.value));
+                    break;
+                case NATIVE_TRANSPORT_PORT_SSL:
+                    peer.setNativePortSsl(Integer.parseInt(value.value));
+                    break;
+                case SCHEMA:
+                    // This fix schedules a schema pull for the non-member node and is required because
+                    // `StorageService.onChange()` doesn't do this for non-member nodes.
+                    MigrationManager.instance.scheduleSchemaPull(endpoint, epState, String.format("gossip schema version change to %s", value.value));
+                    break;
+                case STORAGE_PORT:
+                    peer.setStoragePort(Integer.parseInt(value.value));
+                    break;
+                case STORAGE_PORT_SSL:
+                    peer.setStoragePortSsl(Integer.parseInt(value.value));
+                    break;
+                case JMX_PORT:
+                    peer.setJmxPort(Integer.parseInt(value.value));
+                    break;
+                case HOST_ID:
+                    peer.setHostId(UUID.fromString(value.value));
+                    break;
+                case DSE_GOSSIP_STATE:
+                    updateDseState(value, endpoint, peer);
+                    break;
+            }
+        }
+    }
+
+    public static TableMetadata virtualFromLegacy(TableMetadata legacy, String table)
+    {
+        TableMetadata.Builder builder = TableMetadata.builder(SYSTEM_KEYSPACE_NAME, table)
+                .kind(TableMetadata.Kind.VIRTUAL);
+        legacy.partitionKeyColumns().forEach(cm -> builder.addPartitionKeyColumn(cm.name, cm.type));
+        legacy.staticColumns().forEach(cm -> builder.addStaticColumn(cm.name, cm.type.freeze()));
+        legacy.clusteringColumns().forEach(cm -> builder.addClusteringColumn(cm.name, cm.type));
+        legacy.regularColumns().forEach(cm -> builder.addRegularColumn(cm.name, cm.type.freeze()));
+        return builder.build();
     }
 }

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/DefaultQueryInterceptor.java
@@ -52,18 +52,15 @@ public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointState
     }
 
     @Override
-    public boolean shouldInterceptQuery(CQLStatement statement,
-                                        QueryState state, QueryOptions options,
-                                        Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
-    {
-        return isSystemLocalOrPeers(statement);
-    }
-
-    @Override
     public Single<Result> interceptQuery(QueryHandler handler,
                                          CQLStatement statement, QueryState state, QueryOptions options,
                                          Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
     {
+        if (!isSystemLocalOrPeers(statement))
+        {
+            return null;
+        }
+
         org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
         org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);
         return interceptSystemLocalOrPeers(statement, internalState, internalOptions, queryStartNanoTime);

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/DefaultQueryInterceptor.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/DefaultQueryInterceptor.java
@@ -1,0 +1,158 @@
+package io.stargate.db.dse.impl.interceptors;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryHandler;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.cql3.ResultSet;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.gms.ApplicationState;
+import org.apache.cassandra.gms.EndpointState;
+import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.gms.IEndpointStateChangeSubscriber;
+import org.apache.cassandra.gms.VersionedValue;
+import org.apache.cassandra.service.IEndpointLifecycleSubscriber;
+import org.apache.cassandra.transport.messages.ResultMessage;
+
+import com.google.common.collect.Sets;
+import io.reactivex.Single;
+import io.stargate.db.QueryOptions;
+import io.stargate.db.QueryState;
+import io.stargate.db.Result;
+import io.stargate.db.dse.impl.Conversion;
+import io.stargate.db.dse.impl.StargateSystemKeyspace;
+
+import static io.stargate.db.dse.impl.StargateSystemKeyspace.SYSTEM_KEYSPACE_NAME;
+import static io.stargate.db.dse.impl.StargateSystemKeyspace.isStargateNode;
+import static io.stargate.db.dse.impl.StargateSystemKeyspace.isSystemLocalOrPeers;
+
+/**
+ * A default interceptor implementation that returns only stargate nodes for `system.peers` queries, but also
+ * returns only the same, single token for all stargate nodes (they all own the whole ring) for both `system.local`
+ * and `system.peers` tables.
+ */
+public class DefaultQueryInterceptor implements QueryInterceptor, IEndpointStateChangeSubscriber
+{
+    private final List<IEndpointLifecycleSubscriber> subscribers = new CopyOnWriteArrayList<>();
+    private final Set<InetAddress> liveStargateNodes = Sets.newConcurrentHashSet();
+
+    @Override
+    public void initialize()
+    {
+        StargateSystemKeyspace.initialize();
+        Gossiper.instance.register(StargateSystemKeyspace.instance.getPeersUpdater());
+        Gossiper.instance.register(this);
+        StargateSystemKeyspace.instance.persistLocalMetadata();
+    }
+
+    @Override
+    public boolean shouldInterceptQuery(CQLStatement statement,
+                                        QueryState state, QueryOptions options,
+                                        Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
+    {
+        return isSystemLocalOrPeers(statement);
+    }
+
+    @Override
+    public Single<Result> interceptQuery(QueryHandler handler,
+                                         CQLStatement statement, QueryState state, QueryOptions options,
+                                         Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
+    {
+        org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
+        org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);
+        return interceptSystemLocalOrPeers(statement, internalState, internalOptions, queryStartNanoTime);
+    }
+
+    @Override
+    public void register(IEndpointLifecycleSubscriber subscriber)
+    {
+        subscribers.add(subscriber);
+    }
+
+    @Override
+    public void onJoin(InetAddress endpoint, EndpointState epState)
+    {
+        addStargateNode(endpoint, epState);
+    }
+
+    @Override
+    public void beforeChange(InetAddress endpoint, EndpointState currentState, ApplicationState newStateKey, VersionedValue newValue)
+    {
+
+    }
+
+    @Override
+    public void onChange(InetAddress endpoint, ApplicationState state, VersionedValue value)
+    {
+        EndpointState epState = Gossiper.instance.getEndpointStateForEndpoint(endpoint);
+        if (epState == null || Gossiper.instance.isDeadState(epState))
+        {
+            return;
+        }
+
+        addStargateNode(endpoint, epState);
+    }
+
+    @Override
+    public void onAlive(InetAddress endpoint, EndpointState state)
+    {
+
+    }
+
+    @Override
+    public void onDead(InetAddress endpoint, EndpointState state)
+    {
+
+    }
+
+    @Override
+    public void onRemove(InetAddress endpoint)
+    {
+        if (!liveStargateNodes.remove(endpoint))
+        {
+            return;
+        }
+
+        for (IEndpointLifecycleSubscriber subscriber : subscribers)
+            subscriber.onLeaveCluster(endpoint);
+    }
+
+    @Override
+    public void onRestart(InetAddress endpoint, EndpointState state)
+    {
+
+    }
+
+    private void addStargateNode(InetAddress endpoint, EndpointState epState)
+    {
+        if (!isStargateNode(epState) || !liveStargateNodes.add(endpoint))
+        {
+            return;
+        }
+
+        for (IEndpointLifecycleSubscriber subscriber : subscribers)
+            subscriber.onJoinCluster(endpoint);
+    }
+
+    private static Single<Result> interceptSystemLocalOrPeers(CQLStatement statement, org.apache.cassandra.service.QueryState state,
+                                                              org.apache.cassandra.cql3.QueryOptions options,
+                                                              long queryStartNanoTime)
+    {
+        SelectStatement selectStatement = ((SelectStatement) statement);
+
+        // Re-parse so that we can intercept and replace the keyspace.
+        SelectStatement.Raw rawStatement = (SelectStatement.Raw)QueryProcessor.parseStatement(selectStatement.queryString);
+        rawStatement.setKeyspace(SYSTEM_KEYSPACE_NAME);
+
+        SelectStatement interceptStatement = rawStatement.prepare(state.getClientState());
+        Single<ResultMessage.Rows> rows = interceptStatement.execute(state, options, queryStartNanoTime);
+        return rows.map(r ->
+                Conversion.toResult(new ResultMessage.Rows(new ResultSet(selectStatement.getResultMetadata(), r.result.rows)), options.getProtocolVersion()));
+    }
+}

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/ProxyProtocolQueryInterceptor.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/ProxyProtocolQueryInterceptor.java
@@ -1,0 +1,137 @@
+package io.stargate.db.dse.impl.interceptors;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.ColumnSpecification;
+import org.apache.cassandra.cql3.QueryHandler;
+import org.apache.cassandra.cql3.ResultSet;
+import org.apache.cassandra.cql3.statements.SelectStatement;
+import org.apache.cassandra.db.SystemKeyspace;
+import org.apache.cassandra.db.marshal.InetAddressType;
+import org.apache.cassandra.db.marshal.Int32Type;
+import org.apache.cassandra.db.marshal.SetType;
+import org.apache.cassandra.db.marshal.UTF8Type;
+import org.apache.cassandra.db.marshal.UUIDType;
+import org.apache.cassandra.schema.SchemaConstants;
+import org.apache.cassandra.service.IEndpointLifecycleSubscriber;
+import org.apache.cassandra.transport.ProtocolVersion;
+import org.apache.cassandra.transport.messages.ResultMessage;
+
+import com.datastax.bdp.db.nodes.virtual.LocalNodeSystemView;
+import com.datastax.bdp.db.nodes.virtual.PeersSystemView;
+import io.reactivex.Single;
+import io.stargate.db.QueryOptions;
+import io.stargate.db.QueryState;
+import io.stargate.db.Result;
+import io.stargate.db.dse.impl.Conversion;
+import io.stargate.db.dse.impl.StargateSystemKeyspace;
+
+/**
+ * A query interceptor that echos back the public IPs from the proxy protocol from `system.local`. The goal is to populate `system.peers`
+ * with A-records from a provided DNS name.
+ */
+public class ProxyProtocolQueryInterceptor implements QueryInterceptor
+{
+    @Override
+    public void initialize()
+    {
+    }
+
+    @Override
+    public boolean shouldInterceptQuery(CQLStatement statement,
+                                        QueryState state, QueryOptions options,
+                                        Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
+    {
+        if (statement instanceof SelectStatement)
+        {
+            SelectStatement selectStatement = (SelectStatement) statement;
+            String tableName = selectStatement.table();
+            return selectStatement.keyspace().equals(SchemaConstants.SYSTEM_VIEWS_KEYSPACE_NAME) &&
+                    (tableName.equals(LocalNodeSystemView.NAME) || tableName.equals(PeersSystemView.NAME)) ;
+        }
+        return false;
+    }
+
+    @Override
+    public Single<Result> interceptQuery(QueryHandler handler, CQLStatement statement,
+                                         QueryState state, QueryOptions options,
+                                         Map<String, ByteBuffer> customPayload, long queryStartNanoTime)
+    {
+        SelectStatement selectStatement = (SelectStatement) statement;
+
+        org.apache.cassandra.cql3.QueryOptions internalOptions = Conversion.toInternal(options);
+        org.apache.cassandra.service.QueryState internalState = Conversion.toInternal(state);
+
+        ProtocolVersion version = internalOptions.getProtocolVersion();
+
+        String tableName = selectStatement.table();
+        if (tableName.equals(PeersSystemView.NAME))
+        {
+            // Returning an empty result for now, but this will return the result of the proxy's DNS A records in the future
+            return Single.just(Conversion.toResult(new ResultMessage.Rows(new org.apache.cassandra.cql3.ResultSet(((SelectStatement) statement).getResultMetadata())), version));
+        }
+        else
+        {
+            assert tableName.equals(LocalNodeSystemView.NAME);
+
+            Single<ResultMessage> resp = handler.processStatement(statement, internalState, internalOptions, customPayload, queryStartNanoTime);
+
+            return resp
+                    .map((result) ->
+                    {
+                        if (result.kind == ResultMessage.Kind.ROWS)
+                        {
+                            ResultMessage.Rows rows = (ResultMessage.Rows) result;
+                            if (!rows.result.isEmpty())
+                            {
+                                ResultSet.ResultMetadata metadata = rows.result.metadata;
+                                InetAddress publicAddress = state.getClientState().getPublicAddress().getAddress();
+                                int publicPort = state.getClientState().getPublicAddress().getPort();
+
+                                int index = 0;
+                                // Intercept and replace all address/port entries with the proxy protocol's public address and port
+                                for (ColumnSpecification column : metadata.names)
+                                {
+                                    switch (column.name.toString())
+                                    {
+                                        case "rpc_address":
+                                        case "peer_address":
+                                        case "broadcast_address":
+                                        case "native_transport_address":
+                                        case "listen_address":
+                                            rows.result.rows.get(0).set(index, InetAddressType.instance.decompose(publicAddress));
+                                            break;
+                                        case "native_transport_port":
+                                        case "native_transport_port_ssl":
+                                            rows.result.rows.get(0).set(index, Int32Type.instance.decompose(publicPort));
+                                            break;
+                                        case "host_id":
+                                            // Return a deterministic entry for `host_id` based on the public address.
+                                            rows.result.rows.get(0).set(index, UUIDType.instance.decompose(UUID.nameUUIDFromBytes(publicAddress.getAddress())));
+                                            break;
+                                        case "tokens":
+                                            // All entries handle the entire token ring. This prevents some driver from crashing when `tokens` is null.
+                                            rows.result.rows.get(0).set(index, SetType.getInstance(UTF8Type.instance, false).decompose(Collections.singleton(DatabaseDescriptor.getPartitioner().getMinimumToken().toString())));
+                                    }
+                                    ++index;
+                                }
+                            }
+                        }
+                        return Conversion.toResult(result, version);
+                    });
+        }
+    }
+
+
+    @Override
+    public void register(IEndpointLifecycleSubscriber subscriber)
+    {
+        // TODO: Monitor A-records for DNS to generate events for stargate peers
+    }
+}

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/QueryInterceptor.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/QueryInterceptor.java
@@ -20,10 +20,6 @@ public interface QueryInterceptor
 {
     void initialize();
 
-    boolean shouldInterceptQuery(CQLStatement statement,
-                                 QueryState state, QueryOptions options,
-                                 Map<String, ByteBuffer> customPayload, long queryStartNanoTime);
-
     Single<Result> interceptQuery(QueryHandler handler,
                                   CQLStatement statement, QueryState state, QueryOptions options,
                                   Map<String, ByteBuffer> customPayload, long queryStartNanoTime);

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/QueryInterceptor.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/interceptors/QueryInterceptor.java
@@ -1,0 +1,32 @@
+package io.stargate.db.dse.impl.interceptors;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import org.apache.cassandra.cql3.CQLStatement;
+import org.apache.cassandra.cql3.QueryHandler;
+import org.apache.cassandra.service.IEndpointLifecycleSubscriber;
+
+import io.reactivex.Single;
+import io.stargate.db.QueryOptions;
+import io.stargate.db.QueryState;
+import io.stargate.db.Result;
+
+/**
+ * An interface for intercepting queries and node lifecycle events. It's used to intercept `system.local`
+ * and `system.peers` queries and topology events for stargate nodes.
+ */
+public interface QueryInterceptor
+{
+    void initialize();
+
+    boolean shouldInterceptQuery(CQLStatement statement,
+                                 QueryState state, QueryOptions options,
+                                 Map<String, ByteBuffer> customPayload, long queryStartNanoTime);
+
+    Single<Result> interceptQuery(QueryHandler handler,
+                                  CQLStatement statement, QueryState state, QueryOptions options,
+                                  Map<String, ByteBuffer> customPayload, long queryStartNanoTime);
+
+    void register(IEndpointLifecycleSubscriber subscriber);
+}


### PR DESCRIPTION
Also, fix cases where non-stargate nodes could end up in `system.peers`