### PR TITLE
Wait for schema migration to occur during startup

### DIFF
--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -67,6 +67,16 @@ public class CassandraPersistence
         Config, org.apache.cassandra.service.ClientState, org.apache.cassandra.service.QueryState> {
   private static final Logger logger = LoggerFactory.getLogger(CassandraPersistence.class);
 
+  /*
+   * Initial schema migration can take greater than 2 * MigrationManager.MIGRATION_DELAY_IN_MS if a
+   * live token owner doesn't become live within MigrationManager.MIGRATION_DELAY_IN_MS.
+   */
+  private static final int STARTUP_DELAY_MS =
+      Integer.parseInt(
+          System.getProperty(
+              "stargate.startup_delay_ms",
+              "180000")); // MigrationManager.MIGRATION_DELAY_IN_MS is private
+
   private DataStore root;
   private CassandraDaemon daemon;
   private Authenticator authenticator;
@@ -101,7 +111,7 @@ public class CassandraPersistence
 
     daemon.start();
 
-    waitForSchema(5 * StorageService.RING_DELAY);
+    waitForSchema(STARTUP_DELAY_MS);
 
     root = new InternalDataStore();
     authenticator = new AuthenticatorWrapper(DatabaseDescriptor.getAuthenticator());
@@ -558,14 +568,22 @@ public class CassandraPersistence
    * for at least one backend ring member to become available and for their schemas to agree before
    * allowing initialization to continue.
    */
-  private void waitForSchema(int delay) {
-    for (int i = 0; i < delay; i += 1000) {
+  private void waitForSchema(int delayMillis) {
+    boolean isConnectedAndInAgreement = false;
+    for (int i = 0; i < delayMillis; i += 1000) {
       if (Gossiper.instance.getLiveTokenOwners().size() > 0 && isInSchemaAgreement()) {
         logger.debug("current schema version: {}", Schema.instance.getVersion());
+        isConnectedAndInAgreement = true;
         break;
       }
 
       Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+    }
+
+    if (!isConnectedAndInAgreement) {
+      logger.warn(
+          "Unable to connect to live token owner and/or reach schema agreement after {} milliseconds",
+          delayMillis);
     }
   }
 }

--- a/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
+++ b/persistence-cassandra-4.0/src/main/java/io/stargate/db/cassandra/impl/CassandraPersistence.java
@@ -72,10 +72,9 @@ public class CassandraPersistence
    * live token owner doesn't become live within MigrationManager.MIGRATION_DELAY_IN_MS.
    */
   private static final int STARTUP_DELAY_MS =
-      Integer.parseInt(
-          System.getProperty(
-              "stargate.startup_delay_ms",
-              "180000")); // MigrationManager.MIGRATION_DELAY_IN_MS is private
+      Integer.getInteger(
+          "stargate.startup_delay_ms",
+          3 * 60000); // MigrationManager.MIGRATION_DELAY_IN_MS is private
 
   private DataStore root;
   private CassandraDaemon daemon;

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -71,10 +71,7 @@ public class DsePersistence
    * live token owner doesn't become live within MigrationManager.MIGRATION_DELAY_IN_MS.
    */
   private static final int STARTUP_DELAY_MS =
-      Integer.parseInt(
-          System.getProperty(
-              "stargate.startup_delay_ms",
-              Integer.toString(3 * MigrationManager.MIGRATION_DELAY_IN_MS)));
+      Integer.getInteger("stargate.startup_delay_ms", 3 * MigrationManager.MIGRATION_DELAY_IN_MS);
 
   private CassandraDaemon cassandraDaemon;
   private DataStore root;

--- a/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
+++ b/persistence-dse-6.8/src/main/java/io/stargate/db/dse/impl/DsePersistence.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.cql3.statements.ModificationStatement;
 import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.gms.ApplicationState;
 import org.apache.cassandra.gms.Gossiper;
+import org.apache.cassandra.schema.MigrationManager;
 import org.apache.cassandra.schema.SchemaManager;
 import org.apache.cassandra.service.CassandraDaemon;
 import org.apache.cassandra.service.ClientState;
@@ -64,6 +65,16 @@ public class DsePersistence
 
   public static final Boolean USE_PROXY_PROTOCOL =
       Boolean.parseBoolean(System.getProperty("stargate.use_proxy_protocol", "false"));
+
+  /*
+   * Initial schema migration can take greater than 2 * MigrationManager.MIGRATION_DELAY_IN_MS if a
+   * live token owner doesn't become live within MigrationManager.MIGRATION_DELAY_IN_MS.
+   */
+  private static final int STARTUP_DELAY_MS =
+      Integer.parseInt(
+          System.getProperty(
+              "stargate.startup_delay_ms",
+              Integer.toString(3 * MigrationManager.MIGRATION_DELAY_IN_MS)));
 
   private CassandraDaemon cassandraDaemon;
   private DataStore root;
@@ -114,7 +125,7 @@ public class DsePersistence
     Gossiper.instance.addLocalApplicationState(
         ApplicationState.X10, StorageService.instance.valueFactory.dsefsState("stargate"));
 
-    waitForSchema(5 * StorageService.RING_DELAY);
+    waitForSchema(STARTUP_DELAY_MS);
 
     if (USE_PROXY_PROTOCOL) interceptor = new ProxyProtocolQueryInterceptor();
     else interceptor = new DefaultQueryInterceptor();
@@ -564,14 +575,22 @@ public class DsePersistence
    * for at least one backend ring member to become available and for their schemas to agree before
    * allowing initialization to continue.
    */
-  private void waitForSchema(int delay) {
-    for (int i = 0; i < delay; i += 1000) {
+  private void waitForSchema(int delayMillis) {
+    boolean isConnectedAndInAgreement = false;
+    for (int i = 0; i < delayMillis; i += 1000) {
       if (Gossiper.instance.getLiveTokenOwners().size() > 0 && isInSchemaAgreement()) {
         logger.debug("current schema version: {}", SchemaManager.instance.getVersion());
+        isConnectedAndInAgreement = true;
         break;
       }
 
       Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+    }
+
+    if (!isConnectedAndInAgreement) {
+      logger.warn(
+          "Unable to connect to live token owner and/or reach schema agreement after {} milliseconds",
+          delayMillis);
     }
   }
 }


### PR DESCRIPTION
Added property configuration to make this configurable; however, it
should wait greater than the twice migration manager's delay value.